### PR TITLE
Infer compartment from the metadata service if not set explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,14 +31,14 @@ test:
 
 .PHONY: build
 build: ${DIR}/${BIN}
+	@sed "s/{{VERSION}}/$(VERSION)/g" manifests/oci-volume-provisioner.yaml > $(DIR)/oci-volume-provisioner.yaml
 
 ${DIR}/${BIN}: ${GO_SRC}
 	mkdir -p ${DIR}
 	GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 go build -i -v -ldflags '-extldflags "-static"' -o $@ ./cmd/
 
 .PHONY: image
-image: ${DIR}/${BIN}
-	sed "s/{{VERSION}}/$(VERSION)/g" manifests/oci-volume-provisioner.yaml > $(DIR)/oci-volume-provisioner.yaml
+image: build
 	docker build -t ${IMAGE}:${VERSION} .
 
 .PHONY: push

--- a/ci-docker-images/oci-volume-provisioner-system-test/Dockerfile
+++ b/ci-docker-images/oci-volume-provisioner-system-test/Dockerfile
@@ -26,7 +26,7 @@ RUN tar -xzvf linux.tar.gz -C /
 RUN echo "providers { oci = \"/linux_amd64/terraform-provider-oci_v${OCI_TERRAFORM_PROVIDER_VERSION}\" }" > ~/.terraformrc
 
 # Installs the python Oracle OCI client.
-RUN install \
+RUN pip install \
     oci \
     requests[security]
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"flag"
+	"os"
 	"syscall"
 	"time"
 
@@ -63,9 +64,15 @@ func main() {
 		glog.Fatalf("Error getting server version: %v", err)
 	}
 
+	// TODO (owainlewis) ensure this is clearly documented
+	nodeName := os.Getenv("NODE_NAME")
+	if nodeName == "" {
+		glog.Fatal("env variable NODE_NAME must be set so that this provisioner can identify itself")
+	}
+
 	// Create the provisioner: it implements the Provisioner interface expected by
 	// the controller
-	ociProvisioner := provisioner.NewOCIProvisioner()
+	ociProvisioner := provisioner.NewOCIProvisioner(nodeName)
 
 	// Start the provision controller which will dynamically provision oci
 	// PVs

--- a/manifests/example-claim-AD1.yaml
+++ b/manifests/example-claim-AD1.yaml
@@ -4,10 +4,9 @@ metadata:
   name: demooci
 spec:
   storageClassName: "oci"
-  selector: 
+  selector:
     matchLabels:
       oci-availability-domain: "PHX-AD-1"
-      oci-compartment: "kubernetes-test"
   accessModes:
     - ReadWriteOnce
   resources:

--- a/manifests/example-claim-AD2.yaml
+++ b/manifests/example-claim-AD2.yaml
@@ -4,10 +4,9 @@ metadata:
   name: demooci
 spec:
   storageClassName: "oci"
-  selector: 
+  selector:
     matchLabels:
       oci-availability-domain: "PHX-AD-2"
-      oci-compartment: "kubernetes-test"
   accessModes:
     - ReadWriteOnce
   resources:

--- a/manifests/example-claim-AD3.yaml
+++ b/manifests/example-claim-AD3.yaml
@@ -4,10 +4,9 @@ metadata:
   name: demooci
 spec:
   storageClassName: "oci"
-  selector: 
+  selector:
     matchLabels:
       oci-availability-domain: "PHX-AD-3"
-      oci-compartment: "kubernetes-test"
   accessModes:
     - ReadWriteOnce
   resources:

--- a/manifests/example-claim.yaml
+++ b/manifests/example-claim.yaml
@@ -4,10 +4,9 @@ metadata:
   name: demooci
 spec:
   storageClassName: "oci"
-  selector: 
+  selector:
     matchLabels:
       oci-availability-domain: "PHX-AD-1"
-      oci-compartment: "kubernetes-test"
   accessModes:
     - ReadWriteOnce
   resources:

--- a/manifests/oci-volume-provisioner-config-example.yaml
+++ b/manifests/oci-volume-provisioner-config-example.yaml
@@ -7,3 +7,4 @@ auth:
     -----END RSA PRIVATE KEY-----
   fingerprint: 4d:f5:ff:0e:a9:10:e8:5a:d3:52:6a:f8:1e:99:a3:47
   region: us-phoenix-1
+  compartment: ocid1.compartment.oc1..aaaaaaaa6yrzvtwcumheirxtmbrbrya5lqkr7k7lxi34q3egeseqwlq2l5aq

--- a/manifests/oci-volume-provisioner.yaml
+++ b/manifests/oci-volume-provisioner.yaml
@@ -30,4 +30,3 @@ spec:
     - name: config
       secret:
         secretName: oci-volume-provisioner
-        

--- a/pkg/oci/client/client.go
+++ b/pkg/oci/client/client.go
@@ -1,0 +1,17 @@
+package client
+
+import baremetal "github.com/oracle/bmcs-go-sdk"
+
+// FromConfig creates a baremetal client from the given configuration.
+func FromConfig(cfg *Config) (*baremetal.Client, error) {
+	ociClient, err := baremetal.NewClient(
+		cfg.Auth.UserOCID,
+		cfg.Auth.TenancyOCID,
+		cfg.Auth.Fingerprint,
+		baremetal.PrivateKeyBytes([]byte(cfg.Auth.PrivateKey)),
+		baremetal.Region(cfg.Auth.Region))
+	if err != nil {
+		return nil, err
+	}
+	return ociClient, nil
+}

--- a/pkg/oci/client/config.go
+++ b/pkg/oci/client/config.go
@@ -19,18 +19,18 @@ import (
 	"io"
 	"io/ioutil"
 
-	baremetal "github.com/oracle/bmcs-go-sdk"
 	"gopkg.in/yaml.v2"
 )
 
 // AuthConfig holds the configuration required for communicating with the OCI
 // API.
 type AuthConfig struct {
-	TenancyOCID string `yaml:"tenancy"`
-	UserOCID    string `yaml:"user"`
-	PrivateKey  string `yaml:"key"`
-	Fingerprint string `yaml:"fingerprint"`
-	Region      string `yaml:"region"`
+	TenancyOCID     string `yaml:"tenancy"`
+	UserOCID        string `yaml:"user"`
+	CompartmentOCID string `yaml:"compartment"`
+	PrivateKey      string `yaml:"key"`
+	Fingerprint     string `yaml:"fingerprint"`
+	Region          string `yaml:"region"`
 }
 
 // Config holds the OCI cloud-provider config passed to Kubernetes compontents.
@@ -43,33 +43,23 @@ func (c *Config) Validate() error {
 	return ValidateConfig(c).ToAggregate()
 }
 
-// LoadConfig consumes the config and constructs a Config object.
+// LoadConfig consumes the config Reader and constructs a Config object.
 func LoadConfig(r io.Reader) (*Config, error) {
 	if r == nil {
 		return nil, errors.New("no configuration file given")
 	}
+
 	cfg := &Config{}
+
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
+
 	err = yaml.Unmarshal(b, &cfg)
 	if err != nil {
 		return nil, err
 	}
-	return cfg, nil
-}
 
-// FromConfig creates a baremetal client from the given configuration
-func FromConfig(cfg *Config) (client *baremetal.Client, err error) {
-	ociClient, err := baremetal.NewClient(
-		cfg.Auth.UserOCID,
-		cfg.Auth.TenancyOCID,
-		cfg.Auth.Fingerprint,
-		baremetal.PrivateKeyBytes([]byte(cfg.Auth.PrivateKey)),
-		baremetal.Region(cfg.Auth.Region))
-	if err != nil {
-		return nil, err
-	}
-	return ociClient, nil
+	return cfg, nil
 }

--- a/pkg/oci/client/config_test.go
+++ b/pkg/oci/client/config_test.go
@@ -30,6 +30,7 @@ const validConfig = `
 auth:
   region: us-phoenix-1
   tenancy: ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq
+  compartment: ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq
   user: ocid1.user.oc1..aaaaaaaai77mql2xerv7cn6wu3nhxang3y4jk56vo5bn5l5lysl34avnui3q
   key: |
     -----BEGIN RSA PRIVATE KEY-----
@@ -64,7 +65,6 @@ auth:
 const validConfigNoRegion = `
 auth:
   tenancy: ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq
-  compartment: ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq
   user: ocid1.user.oc1..aaaaaaaai77mql2xerv7cn6wu3nhxang3y4jk56vo5bn5l5lysl34avnui3q
   key: |
     -----BEGIN RSA PRIVATE KEY-----
@@ -111,5 +111,14 @@ func TestLoadClientConfigShouldHaveNoDefaultRegionIfNoneSpecified(t *testing.T) 
 	}
 	if config.Auth.Region != "" {
 		t.Errorf("expected no region but got %s", config.Auth.Region)
+	}
+}
+
+func TestLoadConfigShouldHaveCompartment(t *testing.T) {
+	config, _ := LoadConfig(strings.NewReader(validConfig))
+	expected := "ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq"
+	actual := config.Auth.CompartmentOCID
+	if actual != expected {
+		t.Errorf("expected compartment %s but found %s", expected, actual)
 	}
 }

--- a/wercker.yml
+++ b/wercker.yml
@@ -47,7 +47,7 @@ push:
       name: set ENV vars
       code: |
         export VERSION=$(cat VERSION.txt)
-        echo "${VERSION}"
+        echo "Pushing version ${VERSION}"
 
     - script:
       name: prepare
@@ -56,18 +56,15 @@ push:
         chmod +x /oci-volume-provisioner
 
     - internal/docker-push:
-      repository: $DOCKER_REGISTRY_USERNAME/oci-volume-provisioner
-      registry: https://wcr.io/v2
-      username: $DOCKER_REGISTRY_USERNAME
-      password: $DOCKER_REGISTRY_PASSWORD
+      repository: wcr.io/oracle/oci-volume-provisioner
       tag: $VERSION
       entrypoint: /oci-volume-provisioner
       user: 65534 # nobody
 
 system-test:
   box:
-    id: wcr.io/$DOCKER_REGISTRY_USERNAME/oci-volume-provisioner-system-test:1.0.0
-    registry: https://wcr.io/v2
+    id: wcr.io/oracle/oci-volume-provisioner-system-test:1.0.0
+    registry: wcr.io
     username: $DOCKER_REGISTRY_USERNAME
     password: $DOCKER_REGISTRY_PASSWORD
   steps:


### PR DESCRIPTION
Fixes #18 

This change was requested by OKE and it will infer the compartment from metadata service if not set explicitly in config.

To do this cleanly we have made the decision to use an OCID for compartment NOT the compartment name. This saves us having to do a HTTP call to the API and infer it dynamically. 

The compartment is now either set directly in configuration OR it will be dynamically inferred from the metadata service.

Example of explicitly declaring the configuration

```yaml
auth:
  tenancy: ocid1.tenancy.oc1..a
  user: ocid1.user.oc1..aaaaa
  key: |
    -----BEGIN RSA PRIVATE KEY-----
    <snip>
    -----END RSA PRIVATE KEY-----
  fingerprint: 4d:f5:ff:0e:a9:10:e8:5a:d3:52:6a:f8:1e:99:a3:47
  region: us-phoenix-1
  compartment: ocid1.compartment.oc1..aaaaaaaa6yrzvtwcumheirxtmbr
```

Example logs when compartment is not specified.

Further work is needed in this project to make the provisioner testable.

<img width="1883" alt="screen shot 2017-10-25 at 11 59 25" src="https://user-images.githubusercontent.com/733944/31998387-9aae3372-b987-11e7-89a8-18c12b17ee77.png">


