### PR TITLE
Fix issue with image registry + CI image tidy up

### DIFF
--- a/ci-docker-images/oci-volume-provisioner-system-test/Dockerfile
+++ b/ci-docker-images/oci-volume-provisioner-system-test/Dockerfile
@@ -1,11 +1,10 @@
 FROM ubuntu:16.04
 
-ARG PROXY
 ARG TERRAFORM_VERSION=0.10.7
-ARG OCI_TERRAFORM_PROVIDER_VERSION="v2.0.1"
+ARG OCI_TERRAFORM_PROVIDER_VERSION="2.0.2"
 
 # Installs the required dependencies.
-RUN http_proxy=$PROXY apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y \
     git \
     libssl-dev \
     openssh-client \
@@ -17,21 +16,21 @@ RUN http_proxy=$PROXY apt-get update && apt-get install -y \
     curl
 
 # Installs terraform.
-RUN https_proxy=$PROXY wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 RUN unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 RUN mv terraform /usr/bin/
 
 # Installs the OCI terraform provider.
-RUN https_proxy=$PROXY wget https://github.com/oracle/terraform-provider-oci/releases/download/v2.0.1/linux.tar.gz
+RUN wget https://github.com/oracle/terraform-provider-oci/releases/download/${OCI_TERRAFORM_PROVIDER_VERSION}/linux.tar.gz
 RUN tar -xzvf linux.tar.gz -C /
-RUN echo "providers { oci = \"/linux_amd64/terraform-provider-oci_${OCI_TERRAFORM_PROVIDER_VERSION}\" }" > ~/.terraformrc
+RUN echo "providers { oci = \"/linux_amd64/terraform-provider-oci_v${OCI_TERRAFORM_PROVIDER_VERSION}\" }" > ~/.terraformrc
 
 # Installs the python Oracle OCI client.
-RUN https_proxy=$PROXY pip install \
+RUN install \
     oci \
     requests[security]
 
 # Installs the kubectl client
-RUN https_proxy=$PROXY curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
 RUN chmod +x ./kubectl
 RUN mv ./kubectl /usr/local/bin/kubectl

--- a/ci-docker-images/oci-volume-provisioner-system-test/Makefile
+++ b/ci-docker-images/oci-volume-provisioner-system-test/Makefile
@@ -1,13 +1,14 @@
-DOCKER_REPO ?= wcr.io
-DOCKER_USER ?= oracle
+DOCKER_REGISTRY ?= wcr.io
 DOCKER_IMAGE_NAME ?= oci-volume-provisioner-system-test
 DOCKER_IMAGE_TAG ?= 1.0.0
 
 .PHONY: build
 build:
-	docker build --build-arg PROXY=${http_proxy} -t ${DOCKER_REPO}/${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} .
+	docker build --build-arg http_proxy=${http_proxy} \
+		         --build-arg https_proxy=${https_proxy} \
+				 -t ${DOCKER_REGISTRY}/${DOCKER_REGISTRY_USERNAME}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} .
 
 .PHONY: push
 push: build
-	docker login -u '$(DOCKER_REGISTRY_USERNAME)' -p '$(DOCKER_REGISTRY_PASSWORD)' $(DOCKER_REPO)
-	docker push ${DOCKER_REPO}/${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
+	docker login -u '$(DOCKER_REGISTRY_USERNAME)' -p '$(DOCKER_REGISTRY_PASSWORD)' $(DOCKER_REGISTRY)
+	docker push ${DOCKER_REGISTRY}/${DOCKER_REGISTRY_USERNAME}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}

--- a/wercker.yml
+++ b/wercker.yml
@@ -56,7 +56,7 @@ push:
         chmod +x /oci-volume-provisioner
 
     - internal/docker-push:
-      repository: oracle/oci-volume-provisioner
+      repository: $DOCKER_REGISTRY_USERNAME/oci-volume-provisioner
       registry: https://wcr.io/v2
       username: $DOCKER_REGISTRY_USERNAME
       password: $DOCKER_REGISTRY_PASSWORD
@@ -66,7 +66,7 @@ push:
 
 system-test:
   box:
-    id: wcr.io/oracle/oci-volume-provisioner-system-test:1.0.0
+    id: wcr.io/$DOCKER_REGISTRY_USERNAME/oci-volume-provisioner-system-test:1.0.0
     registry: https://wcr.io/v2
     username: $DOCKER_REGISTRY_USERNAME
     password: $DOCKER_REGISTRY_PASSWORD


### PR DESCRIPTION
We now use the DOCKER_REGISTRY_USERNAME in the push to the
provisioner + CI images. We have also tidied up the proxies in the CI image
and bumped the OCI terraform plugin version.