### PR TITLE
CI env vars now base64 encoded

### DIFF
--- a/test/system/runner.py
+++ b/test/system/runner.py
@@ -40,10 +40,10 @@ def _check_env():
 
 def _create_key_files():
     if "OCICONFIG_VAR" in os.environ:
-        _run_command("echo \"$OCICONFIG_VAR\" > " + TMP_OCICONFIG, ".")
+        _run_command("echo \"$OCICONFIG_VAR\" | openssl enc -base64 -d -A > " + TMP_OCICONFIG, ".")
         _run_command("chmod 600 " + TMP_OCICONFIG, ".", verbose=False)
     if "KUBECONFIG_VAR" in os.environ:
-        _run_command("echo \"$KUBECONFIG_VAR\" > " + TMP_KUBECONFIG, ".")
+        _run_command("echo \"$KUBECONFIG_VAR\" | openssl enc -base64 -d -A > " + TMP_KUBECONFIG, ".")
 
     oci_config_file = _get_oci_config_file()
     with open(_get_oci_config_file(), 'r') as stream:


### PR DESCRIPTION
The _VAR environment variables use in CI by the integration and system
tests are now assumed to be base64 encoded, as wercker does not support
newlines in the env vars.