### PR TITLE
Release script added

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+RELEASE=${RELEASE:=0.1.0}
+
+IMAGE=wcr.io/oracle/oci-volume-provisioner
+
+if git rev-parse "$RELEASE" >/dev/null 2>&1; then
+    echo "Tag $RELEASE already exists. Doing nothing"
+else
+    SHA=$(git rev-parse --short=8 HEAD)
+
+    echo "Creating new release $RELEASE for SHA $SHA"
+
+    git tag -a "$RELEASE" -m "Release version: $RELEASE"
+    git push --tags
+
+    docker pull $IMAGE:$SHA
+    docker tag $IMAGE:$SHA $IMAGE:$RELEASE
+    docker push $IMAGE:$RELEASE
+fi


### PR DESCRIPTION
Adds simple (crude) release script that will tag a docker image with a release tag and create a new Github release.

1. Login to Docker with Wercker creds
2. Execute a release RELEASE=0.2.0 hack/release.sh