### PR TITLE
fix test compartment id

### DIFF
--- a/test/system/runner.py
+++ b/test/system/runner.py
@@ -128,22 +128,6 @@ def _poll(stdout, stderr):
                     stderrbuf_line = _process_stream(stream, read_fds, stderrbuf, stderrbuf_line)
     return (''.join(stdoutbuf), ''.join(stderrbuf))
 
-# trjl
-# def _run_command(cmd, cwd, verbose=True):
-#     if verbose:
-#         _log(cwd + ": " + cmd)
-#     process = subprocess.Popen(cmd,
-#                                stdout=subprocess.PIPE,
-#                                stderr=subprocess.PIPE,
-#                                shell=True, cwd=cwd)
-#     (stdout, stderr) = _poll(process.stdout, process.stderr)
-#     returncode = process.wait()
-#     if returncode != 0:
-#         _log("    stdout: " + stdout)
-#         _log("    stderr: " + stderr)
-#         _log("    result: " + str(returncode))
-#     return (stdout, stderr, returncode)
-
 def _run_command(cmd, cwd, display_errors=True):
     _log(cwd + ": " + cmd)
     process = subprocess.Popen(cmd,


### PR DESCRIPTION
1. The compartment_id in the system tests was hard-coded. Now the test runner will determine the compartment id dynamically by resolving it from oci metadata of the 'oci-volume-provisioner' pod.

2. Also has a few output enhancements to hide legitimate errors when starting a test run (e.g. I can delete something I need to deleted because it has been deleted).