### PR TITLE
Add ability to specify custom display name for volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ spec:
         name: nginx-storage
 ```
 
+## Misc
+
+You can add a prefix to volume display names by setting an `OCI_VOLUME_NAME_PREFIX` environment variable.
+
 [1]: http://blog.kubernetes.io/2016/10/dynamic-provisioning-and-storage-in-kubernetes.html
 [2]: https://github.com/oracle/oci-flexvolume-driver
 [3]: https://kubernetes.io/docs/admin/authorization/rbac/

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -6,6 +6,21 @@ import (
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
 )
 
+func TestGetOptionsForVolume(t *testing.T) {
+	volume := getOptionsForVolume(100, "", "myvolume")
+	if volume.DisplayName != "myvolume" {
+		t.Fatalf("Incorrect display name. Expecting %s but got %s", "myvolume", volume.DisplayName)
+	}
+}
+
+func TestGetGetOptionsForVolumeCustomDisplayName(t *testing.T) {
+	volume := getOptionsForVolume(100, "XXX", "myvolume")
+
+	if volume.DisplayName != "XXXmyvolume" {
+		t.Fatalf("Incorrect display name. Expecting %s but got %s", "XXXmyvolume", volume.DisplayName)
+	}
+}
+
 func TestResolveFSTypeWhenNotConfigured(t *testing.T) {
 	options := controller.VolumeOptions{Parameters: make(map[string]string)}
 	// test default fsType of 'ext4' is always returned.


### PR DESCRIPTION
This functionality was accidentally removed in a Gitlab commit and is required by OKE.