### PR TITLE
Remove Docker pull secret from provisioner manifest

### DIFF
--- a/manifests/oci-volume-provisioner.yaml
+++ b/manifests/oci-volume-provisioner.yaml
@@ -11,8 +11,6 @@ spec:
         app: oci-volume-provisioner
     spec:
       serviceAccountName: oci-volume-provisioner
-      imagePullSecrets:
-        - name: wcr-docker-pull-secret
       containers:
         - name: oci-volume-provisioner
           image: wcr.io/oracle/oci-volume-provisioner:0.2.0

--- a/wercker.yml
+++ b/wercker.yml
@@ -70,8 +70,6 @@ system-test:
   box:
     id: wcr.io/oracle/oci-volume-provisioner-system-test:1.0.0
     registry: wcr.io
-    username: $DOCKER_REGISTRY_USERNAME
-    password: $DOCKER_REGISTRY_PASSWORD
   steps:
     - script:
         name: system test


### PR DESCRIPTION
This is no longer required as wcr.io will support anonymous access.