### PR TITLE
Build Version tweaks.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
 GO_SRC := $(shell find . -name "*.go")
-BUILD := $(shell git describe --always --dirty)
 # Allow overriding for release versions
 # Else just equal the build (git hash)
-VERSION ?= ${BUILD}
+BUILD := $(shell git describe --tags --dirty --always)
+ifeq ($(DEV_BUILD), true)
+	# If DEV_BUILD is set, use the dev format.
+	VERSION ?= ${BUILD}-${USER}-dev
+else
+	VERSION ?= ${BUILD}
+endif
 DIR := dist
 BIN := oci-volume-provisioner
 REGISTRY ?= wcr.io


### PR DESCRIPTION
Sort of as we discussed. However, I updated it so that the environment variable 'DEV_BUILD' can be exported to generate version numbers with the developers username in.

I think this is better because: 1) We are not looking for any CI system specific vars; 2) Nearly all of source an environment file before development.

I did originally add a timestamp, but, these images are quite big. I think for me it is enough to have my username in. I guess we could extend this pattern so people could configure a timestamp while in the dev-cycle if we wanted.