### PR TITLE
Return the correct zone if the use uses abrev zones

### DIFF
--- a/pkg/provisioner/core/provisioner_test.go
+++ b/pkg/provisioner/core/provisioner_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"testing"
+)
+
+var TestADSelectionMap = map[string]string{"UK-LONDON-1-AD-3": "UK-LONDON-1-AD-3",
+	"UpwH:UK-LONDON-1-AD-3": "UK-LONDON-1-AD-3",
+	"UpwH:US-PHX-1-AD-3":    "US-PHX-1-AD-3"}
+
+func TestADSelection(t *testing.T) {
+	for key, value := range TestADSelectionMap {
+		result := mapAvailabilityDomainToFailureDomain(key)
+		if result != value {
+			t.Fatalf("mapAvailabilityDomainToFailureDomain %s != %s", result, value)
+		}
+	}
+
+}


### PR DESCRIPTION
The user can use abbreviated zones when creating volumes such as "AD-1" to make the yaml portable across zone (failure-domain.beta.kubernetes.io/zone) . This fixes an issue where the abbreviated zone was used on the volume label and caused any pod that tried to use it as unschedulable.