### PR TITLE
Build + push a reusable (system) test image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 *
 !dist/
+!manifests/
+!test/

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,9 @@
+FROM wcr.io/oracle/oci-volume-provisioner-system-test:1.0.0
+
+COPY dist /dist
+COPY manifests /manifests
+COPY test /test
+
+WORKDIR /test/system
+
+CMD ["./runner.py"]

--- a/test/system/runner.py
+++ b/test/system/runner.py
@@ -332,10 +332,9 @@ def _main():
 
     success = True
 
-    # Cleanup in case any existing state exists in the cluster
-    _cleanup(display_errors=False)
-
     if not args['no_setup']:
+        # Cleanup in case any existing state exists in the cluster
+        _cleanup(display_errors=False)
         _log("Setting up the volume provisioner", as_banner=True)
         if "DOCKER_REGISTRY_USERNAME" in os.environ and "DOCKER_REGISTRY_PASSWORD" in os.environ:
             _kubectl("-n kube-system create secret docker-registry wcr-docker-pull-secret " + \
@@ -353,9 +352,7 @@ def _main():
         _kubectl("create -f ../../dist/oci-volume-provisioner-rbac.yaml", exit_on_error=False)
         _kubectl("create -f ../../dist/oci-volume-provisioner.yaml", exit_on_error=False)
 
-        pod_name, _, _ = _wait_for_pod_status("Running")
-
-    # get the compartment_id of the oci-volume-provisioner
+    pod_name, _, _ = _wait_for_pod_status("Running")
     compartment_id = _get_compartment_id(pod_name)
 
     if not args['no_test']:

--- a/wercker.yml
+++ b/wercker.yml
@@ -66,14 +66,32 @@ push:
 system-test:
   box:
     id: wcr.io/oracle/oci-volume-provisioner-system-test:1.0.0
-    registry: wcr.io
   steps:
     - script:
-        name: system test
-        code: |
-          cd test/system
-          ./runner.py
+      name: set ENV vars
+      code: |
+        export VERSION=$(cat dist/VERSION.txt)
+        echo "Pushing test version ${VERSION}"
 
+    - script:
+      name: prepare
+      code: |
+        mv ./dist /dist
+        mv ./manifests /manifests
+        mv ./test /test
+
+    - internal/docker-push:
+      repository: wcr.io/oracle/oci-volume-provisioner-test
+      tag: $VERSION
+      working-dir: /test/system
+      entrypoint: ./runner.py
+      user: 65534 # nobody
+
+    - script:
+        name: test
+        code: |
+          cd /test/system
+          ./runner.py
 
 release:
   box:


### PR DESCRIPTION
For each build of the volume provisioner, we now will build and push an image containing the end to end test. This image can then be targeted at an existing cluster in order to verify the operation
of a deployed OCI volume provisioner.