### PR TITLE
Optionally check OCI resources in system test

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -91,7 +91,7 @@ system-test:
         name: test
         code: |
           cd /test/system
-          ./runner.py --setup --teardown
+          ./runner.py --setup --check-oci --teardown
 
 release:
   box:


### PR DESCRIPTION
Previously the system test checked that the required OCI
resources (volumes) get created/destroyed. This is now
optional, and the test image will by default run just the
checks possible by specifying the kubeconfig (i.e. not
the OCI checks).