### PR TITLE
Fix clashing issues with system test image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ env.sh
 .wercker
 *.log
 test/system/venv/
-test/system/run-test-image.yaml
+test/system/run-test-image.yaml*

--- a/ci-docker-images/oci-volume-provisioner-system-test/Dockerfile
+++ b/ci-docker-images/oci-volume-provisioner-system-test/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update && apt-get install -y \
     unzip \
     wget \
     curl \
-    jq
+    jq \
+    pwgen
 
 # Installs terraform.
 RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip

--- a/ci-docker-images/oci-volume-provisioner-system-test/Makefile
+++ b/ci-docker-images/oci-volume-provisioner-system-test/Makefile
@@ -1,6 +1,6 @@
 DOCKER_REGISTRY ?= wcr.io
 DOCKER_IMAGE_NAME ?= oci-volume-provisioner-system-test
-DOCKER_IMAGE_TAG ?= 1.0.1
+DOCKER_IMAGE_TAG ?= 1.0.2
 
 .PHONY: build
 build:

--- a/manifests/example-claim-ext3.template
+++ b/manifests/example-claim-ext3.template
@@ -1,7 +1,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: demo-oci-ext3
+  name: demooci-ext3-{{TEST_ID}}
 spec:
   storageClassName: "oci-ext3"
   accessModes:

--- a/manifests/example-claim-ffsw.template
+++ b/manifests/example-claim-ffsw.template
@@ -1,7 +1,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: demooci
+  name: demooci-ffsw-{{TEST_ID}}
 spec:
   storageClassName: "ffsw"
   accessModes:

--- a/manifests/example-claim-no-AD.template
+++ b/manifests/example-claim-no-AD.template
@@ -1,7 +1,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: demooci-no-ad
+  name: demooci-no-ad-{{TEST_ID}}
 spec:
   storageClassName: "oci"
   accessModes:

--- a/manifests/example-claim.template
+++ b/manifests/example-claim.template
@@ -1,7 +1,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: demooci
+  name: demooci-{{TEST_ID}}
 spec:
   storageClassName: "oci"
   selector:

--- a/test/system/run-test-image.yaml.template
+++ b/test/system/run-test-image.yaml.template
@@ -1,7 +1,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: oci-volume-provisioner-system-test
+  name: oci-volume-provisioner-system-test-{{TEST_ID}}
 rules:
   - apiGroups: ["*"]
     resources: ["*"]
@@ -10,29 +10,29 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: oci-volume-provisioner-system-test
+  name: oci-volume-provisioner-system-test-{{TEST_ID}}
 subjects:
   - kind: ServiceAccount
-    name: oci-volume-provisioner-system-test
+    name: oci-volume-provisioner-system-test-{{TEST_ID}}
     namespace: default
 roleRef:
   kind: ClusterRole
-  name: oci-volume-provisioner-system-test
+  name: oci-volume-provisioner-system-test-{{TEST_ID}}
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: oci-volume-provisioner-system-test
+  name: oci-volume-provisioner-system-test-{{TEST_ID}}
   namespace: default
 ---
 apiVersion: v1
 kind: Pod
 metadata:
-  name: volume-provisioner-system-test
+  name: volume-provisioner-system-test-{{TEST_ID}}
 spec:
-  serviceAccountName: oci-volume-provisioner-system-test
+  serviceAccountName: oci-volume-provisioner-system-test-{{TEST_ID}}
   containers:
-  - name: volume-provisioner-system-test
+  - name: volume-provisioner-system-test-{{TEST_ID}}
     image: wcr.io/{{DOCKER_REGISTRY_USERNAME}}/oci-volume-provisioner-test:{{VERSION}}
   restartPolicy: Never

--- a/wercker.yml
+++ b/wercker.yml
@@ -65,7 +65,7 @@ push:
 
 system-test:
   box:
-    id: wcr.io/oracle/oci-volume-provisioner-system-test:1.0.1
+    id: wcr.io/oracle/oci-volume-provisioner-system-test:1.0.2
   steps:
     - script:
       name: set ENV vars
@@ -94,7 +94,7 @@ system-test:
 
 validate-test-image:
   box:
-    id: wcr.io/oracle/oci-volume-provisioner-system-test:1.0.1
+    id: wcr.io/oracle/oci-volume-provisioner-system-test:1.0.2
   steps:
     - script:
       name: set ENV vars


### PR DESCRIPTION
Previously, if more than one instance of the test image
was run in the same cluster at the same time, then some of the
created resources would clash amd the test would fail.
This has now been fixed.