### PR TITLE
Append hyphen to volume name prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,5 @@
 # CHANGELOG
 
-## 0.7.0
-
-- Append hyphen to volume name prefix [#107]
-
-## 0.6.0
-
-## 0.5.0
-
-## 0.4.0
-
-## 0.3.0
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## 0.7.0
+
+- Append hyphen to volume name prefix [#107]
+
+## 0.6.0
+
+## 0.5.0
+
+## 0.4.0
+
+## 0.3.0
 
 ## 0.2.0
 

--- a/pkg/provisioner/block/block.go
+++ b/pkg/provisioner/block/block.go
@@ -103,6 +103,11 @@ func (block *blockProvisioner) Provision(options controller.VolumeOptions,
 
 	ctx, cancel := context.WithTimeout(block.client.Context(), block.client.Timeout())
 	defer cancel()
+	prefix := strings.TrimSpace(os.Getenv(volumePrefixEnvVarName))
+	if prefix != "" && !strings.HasSuffix(prefix, "-") {
+		prefix = fmt.Sprintf("%s%s", prefix, "-")
+	}
+
 	newVolume, err := block.client.BlockStorage().CreateVolume(ctx, core.CreateVolumeRequest{
 		CreateVolumeDetails: volumeDetails,
 	})


### PR DESCRIPTION
Fix: #99 

Should the container environment variable `OCI_VOLUME_NAME_PREFIX` be set to a non-empty value (the prefix), the prefix itself will have the suffix of a hyphen (-).

**Changelog**

`- Append hyphen to volume name prefix. Prefix's will be suffixed with a hyphen if not already so.`