### PR TITLE
Restructure Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## 0.7.0
+
+- Restructure Configuration [#111]
+
+## 0.6.0
+
+## 0.5.0
+
+## 0.4.0
+
+## 0.3.0
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,5 @@
 # CHANGELOG
 
-## 0.7.0
-
-- Restructure Configuration [#111]
-
-## 0.6.0
-
-## 0.5.0
-
-## 0.4.0
-
-## 0.3.0
 
 ## 0.2.0
 

--- a/pkg/oci/client/client.go
+++ b/pkg/oci/client/client.go
@@ -85,7 +85,7 @@ func (p *provisionerClient) Timeout() time.Duration {
 }
 
 func (p *provisionerClient) CompartmentOCID() (compartmentOCID string) {
-	if p.cfg.Auth.CompartmentOCID == "" {
+	if p.cfg.CompartmentOCID == "" {
 		if p.metadata == nil {
 			log.Fatalf("Unable to get compartment OCID. Please provide this via config")
 			return
@@ -93,7 +93,7 @@ func (p *provisionerClient) CompartmentOCID() (compartmentOCID string) {
 		glog.Infof("'CompartmentID' not given. Using compartment OCID %s from instance metadata", p.metadata.CompartmentOCID)
 		compartmentOCID = p.metadata.CompartmentOCID
 	} else {
-		compartmentOCID = p.cfg.Auth.CompartmentOCID
+		compartmentOCID = p.cfg.CompartmentOCID
 	}
 	return
 }
@@ -149,7 +149,7 @@ func newConfigurationProvider(cfg *Config) (common.ConfigurationProvider, error)
 		if err != nil {
 			return nil, errors.Wrap(err, "invalid client config")
 		}
-		if cfg.Auth.UseInstancePrincipals {
+		if cfg.UseInstancePrincipals {
 			glog.V(2).Info("Using instance principals configuration provider")
 			cp, err := auth.InstancePrincipalConfigurationProvider()
 			if err != nil {

--- a/pkg/oci/client/config.go
+++ b/pkg/oci/client/config.go
@@ -77,7 +77,7 @@ func LoadConfig(r io.Reader) (*Config, error) {
 // Complete the config applying defaults / overrides.
 func (c *Config) Complete() {
 	if c.CompartmentOCID == "" && c.Auth.CompartmentOCID != "" {
-		glog.Warning("cloud-provider config: \"auth.compartment\" is DEPRECIATED and will be removed in a later release. Please set \"compartment\".")
+		glog.Warning("cloud-provider config: \"auth.compartment\" is DEPRECATED and will be removed in a later release. Please set \"compartment\".")
 		c.CompartmentOCID = c.Auth.CompartmentOCID
 	}
 }

--- a/pkg/oci/client/config.go
+++ b/pkg/oci/client/config.go
@@ -19,25 +19,31 @@ import (
 	"io"
 	"io/ioutil"
 
+	"github.com/golang/glog"
 	"gopkg.in/yaml.v2"
 )
 
 // AuthConfig holds the configuration required for communicating with the OCI
 // API.
 type AuthConfig struct {
-	TenancyOCID           string `yaml:"tenancy"`
-	UserOCID              string `yaml:"user"`
-	CompartmentOCID       string `yaml:"compartment"`
-	PrivateKey            string `yaml:"key"`
-	Fingerprint           string `yaml:"fingerprint"`
-	Region                string `yaml:"region"`
-	PrivateKeyPassphrase  string `yaml:"passphrase"`
-	UseInstancePrincipals bool   `yaml:"useInstancePrincipals"`
+	TenancyOCID string `yaml:"tenancy"`
+	UserOCID    string `yaml:"user"`
+	// CompartmentOCID is DEPRECATED and should be set on the top level Config
+	// struct.
+	CompartmentOCID      string `yaml:"compartment"`
+	PrivateKey           string `yaml:"key"`
+	Fingerprint          string `yaml:"fingerprint"`
+	Region               string `yaml:"region"`
+	PrivateKeyPassphrase string `yaml:"passphrase"`
 }
 
 // Config holds the OCI cloud-provider config passed to Kubernetes compontents.
 type Config struct {
-	Auth AuthConfig `yaml:"auth"`
+	Auth                  AuthConfig `yaml:"auth"`
+	UseInstancePrincipals bool       `yaml:"useInstancePrincipals"`
+	// CompartmentOCID is the OCID of the Compartment within which the cluster
+	// resides.
+	CompartmentOCID string `yaml:"compartment"`
 }
 
 // Validate validates the OCI config.
@@ -63,5 +69,15 @@ func LoadConfig(r io.Reader) (*Config, error) {
 		return nil, err
 	}
 
+	cfg.Complete()
+
 	return cfg, nil
+}
+
+// Complete the config applying defaults / overrides.
+func (c *Config) Complete() {
+	if c.CompartmentOCID == "" && c.Auth.CompartmentOCID != "" {
+		glog.Warning("cloud-provider config: \"auth.compartment\" is DEPRECIATED and will be removed in a later release. Please set \"compartment\".")
+		c.CompartmentOCID = c.Auth.CompartmentOCID
+	}
 }

--- a/pkg/oci/client/config_validate.go
+++ b/pkg/oci/client/config_validate.go
@@ -18,41 +18,41 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-func validateAuthConfig(c AuthConfig, fldPath *field.Path) field.ErrorList {
+func validateAuthConfig(c Config, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if c.UseInstancePrincipals {
-		if c.Region != "" {
+		if c.Auth.Region != "" {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("region"), "cannot be used when useInstancePrincipals is enabled"))
 		}
-		if c.TenancyOCID != "" {
+		if c.Auth.TenancyOCID != "" {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("tenancy"), "cannot be used when useInstancePrincipals is enabled"))
 		}
-		if c.UserOCID != "" {
+		if c.Auth.UserOCID != "" {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("user"), "cannot be used when useInstancePrincipals is enabled"))
 		}
-		if c.PrivateKey != "" {
+		if c.Auth.PrivateKey != "" {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("key"), "cannot be used when useInstancePrincipals is enabled"))
 		}
-		if c.Fingerprint != "" {
+		if c.Auth.Fingerprint != "" {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("fingerprint"), "cannot be used when useInstancePrincipals is enabled"))
 		}
 		return allErrs
 	}
 
-	if c.Region == "" {
+	if c.Auth.Region == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("region"), ""))
 	}
-	if c.TenancyOCID == "" {
+	if c.Auth.TenancyOCID == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("tenancy"), ""))
 	}
-	if c.UserOCID == "" {
+	if c.Auth.UserOCID == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("user"), ""))
 	}
-	if c.PrivateKey == "" {
+	if c.Auth.PrivateKey == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("key"), ""))
 	}
-	if c.Fingerprint == "" {
+	if c.Auth.Fingerprint == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("fingerprint"), ""))
 	}
 	return allErrs
@@ -61,6 +61,6 @@ func validateAuthConfig(c AuthConfig, fldPath *field.Path) field.ErrorList {
 // ValidateConfig validates the OCI Volume Provisioner config file.
 func ValidateConfig(c *Config) field.ErrorList {
 	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, validateAuthConfig(c.Auth, field.NewPath("auth"))...)
+	allErrs = append(allErrs, validateAuthConfig(*c, field.NewPath("auth"))...)
 	return allErrs
 }

--- a/pkg/oci/client/config_validate_test.go
+++ b/pkg/oci/client/config_validate_test.go
@@ -107,22 +107,21 @@ func TestValidateConfig(t *testing.T) {
 		}, {
 			name: "valid with instance principals enabled",
 			in: &Config{
-				Auth: AuthConfig{
-					UseInstancePrincipals: true,
-				},
+				UseInstancePrincipals: true,
 			},
 			errs: field.ErrorList{},
 		}, {
 			name: "mixing instance principals with other auth flags",
 			in: &Config{
 				Auth: AuthConfig{
-					UseInstancePrincipals: true,
-					Region:                "us-phoenix-1",
-					TenancyOCID:           "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
-					UserOCID:              "ocid1.user.oc1..aaaaaaaai77mql2xerv7cn6wu3nhxang3y4jk56vo5bn5l5lysl34avnui3q",
-					PrivateKey:            "-----BEGIN RSA PRIVATE KEY----- (etc)",
-					Fingerprint:           "8c:bf:17:7b:5f:e0:7d:13:75:11:d6:39:0d:e2:84:74",
+
+					Region:      "us-phoenix-1",
+					TenancyOCID: "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
+					UserOCID:    "ocid1.user.oc1..aaaaaaaai77mql2xerv7cn6wu3nhxang3y4jk56vo5bn5l5lysl34avnui3q",
+					PrivateKey:  "-----BEGIN RSA PRIVATE KEY----- (etc)",
+					Fingerprint: "8c:bf:17:7b:5f:e0:7d:13:75:11:d6:39:0d:e2:84:74",
 				},
+				UseInstancePrincipals: true,
 			},
 			errs: field.ErrorList{
 				&field.Error{Type: field.ErrorTypeForbidden, Field: "auth.region", Detail: "cannot be used when useInstancePrincipals is enabled", BadValue: ""},


### PR DESCRIPTION
Fix: #106 

Restructuring of the AuthConfig. Anything that is not a concern to authentication is placed in the higher level Config. CompartmentOCID has been moved into Config but is still currently supported in AuthConfig for backwards compatibility.

**Changelog**

```
- Restructure configuration format. 'useInstancePrinciples' and 'compartment' are now deprecated under 'auth' and should be declared in the higher level config.
```