### PR TITLE
Changes build to publish docker images to all OCIR regions

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM wcr.io/oracle/oci-volume-provisioner-system-test:1.0.0
+FROM iad.ocir.io/oracle/oci-volume-provisioner-system-test:1.0.0
 
 COPY dist /dist
 COPY manifests /manifests

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ else
 endif
 DIR := dist
 BIN := oci-volume-provisioner
-REGISTRY ?= wcr.io
+REGISTRY ?= iad.ocir.io
 DOCKER_REGISTRY_USERNAME ?= oracle
 IMAGE ?= $(REGISTRY)/$(DOCKER_REGISTRY_USERNAME)/$(BIN)
 TEST_IMAGE ?= $(REGISTRY)/$(DOCKER_REGISTRY_USERNAME)/$(BIN)-test

--- a/ci-docker-images/oci-volume-provisioner-system-test/Makefile
+++ b/ci-docker-images/oci-volume-provisioner-system-test/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DOCKER_REGISTRY ?= wcr.io
+DOCKER_REGISTRY ?= iad.ocir.io
 DOCKER_IMAGE_NAME ?= oci-volume-provisioner-system-test
 DOCKER_IMAGE_TAG ?= 1.0.2
 

--- a/test/system/run-test-image.yaml.template
+++ b/test/system/run-test-image.yaml.template
@@ -34,5 +34,5 @@ spec:
   serviceAccountName: oci-volume-provisioner-system-test-{{TEST_ID}}
   containers:
   - name: volume-provisioner-system-test-{{TEST_ID}}
-    image: wcr.io/{{DOCKER_REGISTRY_USERNAME}}/oci-volume-provisioner-test:{{VERSION}}
+    image: iad.ocir.io/{{DOCKER_REGISTRY_USERNAME}}/oci-volume-provisioner-test:{{VERSION}}
   restartPolicy: Never

--- a/wercker.yml
+++ b/wercker.yml
@@ -71,14 +71,44 @@ push:
         yum install -y openssl ca-certificates && yum clean all
 
     - internal/docker-push:
-      repository: wcr.io/oracle/oci-volume-provisioner
+      repository: iad.ocir.io/oracle/oci-volume-provisioner
       tag: $VERSION
       entrypoint: /oci-volume-provisioner
       user: 65534 # nobody
+      registry: https://iad.ocir.io/v2
+      username: $OCIRUSERNAME
+      password: $OCIRPASSWORD
+
+    - internal/docker-push:
+      repository: lhr.ocir.io/oracle/oci-volume-provisioner
+      tag: $VERSION
+      entrypoint: /oci-volume-provisioner
+      user: 65534 # nobody
+      registry: https://lhr.ocir.io/v2
+      username: $OCIRUSERNAME
+      password: $OCIRPASSWORD
+
+    - internal/docker-push:
+      repository: phx.ocir.io/oracle/oci-volume-provisioner
+      tag: $VERSION
+      entrypoint: /oci-volume-provisioner
+      user: 65534 # nobody
+      registry: https://phx.ocir.io/v2
+      username: $OCIRUSERNAME
+      password: $OCIRPASSWORD
+
+    - internal/docker-push:
+      repository: fra.ocir.io/oracle/oci-volume-provisioner
+      tag: $VERSION
+      entrypoint: /oci-volume-provisioner
+      user: 65534 # nobody
+      registry: https://fra.ocir.io/v2
+      username: $OCIRUSERNAME
+      password: $OCIRPASSWORD
 
 system-test:
   box:
-    id: wcr.io/oracle/oci-volume-provisioner-system-test:1.0.2
+    id: iad.ocir.io/oracle/oci-volume-provisioner-system-test:1.0.2
   steps:
     - script:
       name: set ENV vars
@@ -94,10 +124,13 @@ system-test:
         cp -R ./test /test
 
     - internal/docker-push:
-      repository: wcr.io/oracle/oci-volume-provisioner-test
+      repository: iad.ocir.io/oracle/oci-volume-provisioner-test
       tag: $VERSION
       working-dir: /test/system
       entrypoint: ./runner.py
+      registry: https://iad.ocir.io/v2
+      username: $OCIRUSERNAME
+      password: $OCIRPASSWORD
 
     - script:
         name: test
@@ -107,7 +140,7 @@ system-test:
 
 validate-test-image:
   box:
-    id: wcr.io/oracle/oci-volume-provisioner-system-test:1.0.2
+    id: iad.ocir.io/oracle/oci-volume-provisioner-system-test:1.0.2
   steps:
     - script:
       name: set ENV vars


### PR DESCRIPTION
At this point we push prod/runtime images to all regions, but push the test/system-test
images to iad (Ashburn) region only - this can be tweaked later if we need these in all regions.

Also worth noting i've set all the repo's across the regions to public. Also i've added OCIRUSERNAME and OCIRPASSWORD env vars to wercker env vars config.