### PR TITLE
Use failure-domain.beta.kubernetes.io/zone in match label examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ spec:
   storageClassName: "oci"
   selector:
     matchLabels:
-      oci-availability-domain: "PHX-AD-1"
+      failure-domain.beta.kubernetes.io/zone: "PHX-AD-1"
   accessModes:
     - ReadWriteOnce
   resources:

--- a/examples/example-claim-AD1.yaml
+++ b/examples/example-claim-AD1.yaml
@@ -6,7 +6,7 @@ spec:
   storageClassName: "oci"
   selector:
     matchLabels:
-      oci-availability-domain: "PHX-AD-1"
+      failure-domain.beta.kubernetes.io/zone: "PHX-AD-1"
   accessModes:
     - ReadWriteOnce
   resources:

--- a/examples/example-claim-AD2.yaml
+++ b/examples/example-claim-AD2.yaml
@@ -6,7 +6,7 @@ spec:
   storageClassName: "oci"
   selector:
     matchLabels:
-      oci-availability-domain: "PHX-AD-2"
+      failure-domain.beta.kubernetes.io/zone: "PHX-AD-2"
   accessModes:
     - ReadWriteOnce
   resources:

--- a/examples/example-claim-AD3.yaml
+++ b/examples/example-claim-AD3.yaml
@@ -6,7 +6,7 @@ spec:
   storageClassName: "oci"
   selector:
     matchLabels:
-      oci-availability-domain: "PHX-AD-3"
+      failure-domain.beta.kubernetes.io/zone: "PHX-AD-3"
   accessModes:
     - ReadWriteOnce
   resources:

--- a/examples/example-claim-from-backup.template
+++ b/examples/example-claim-from-backup.template
@@ -8,7 +8,7 @@ spec:
   storageClassName: "oci"
   selector:
     matchLabels:
-      oci-availability-domain: "{{REGION}}"
+      failure-domain.beta.kubernetes.io/zone: "{{REGION}}"
   accessModes:
     - ReadWriteOnce
   resources:

--- a/examples/example-claim.template
+++ b/examples/example-claim.template
@@ -6,7 +6,7 @@ spec:
   storageClassName: "oci"
   selector:
     matchLabels:
-      oci-availability-domain: "{{REGION}}"
+      failure-domain.beta.kubernetes.io/zone: "{{REGION}}"
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
Fixes #138 