### PR TITLE
Adding support for disabling volume roundup

### DIFF
--- a/examples/example-claim-disable-roundup.yaml
+++ b/examples/example-claim-disable-roundup.yaml
@@ -1,0 +1,14 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: demoocinoroundup
+spec:
+  storageClassName: "oci-disableroundup"
+  selector:
+    matchLabels:
+      failure-domain.beta.kubernetes.io/zone: "PHX-AD-1"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 48Gi

--- a/examples/storage-class-disableroundup.yaml
+++ b/examples/storage-class-disableroundup.yaml
@@ -1,0 +1,7 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: oci-disableroundup
+provisioner: oracle.com/oci
+parameters:
+  volumeRoundingUpEnabled: "false"

--- a/pkg/provisioner/block/block.go
+++ b/pkg/provisioner/block/block.go
@@ -122,15 +122,6 @@ func (block *blockProvisioner) waitForVolumeAvailable(volumeID *string, timeout 
 	})
 
 }
-func volumeRoundingEnabled(param map[string]string) bool {
-	volumeRounding := true // default
-	if volumeRoundingUpParam, ok := param[volumeRoundingUpEnabled]; ok {
-		if enabled, err := strconv.ParseBool(volumeRoundingUpParam); err == nil && !enabled {
-			volumeRounding = false
-		}
-	}
-	return volumeRounding
-}
 
 func volumeRoundingEnabled(param map[string]string) bool {
 	volumeRounding := true // default

--- a/pkg/provisioner/block/block.go
+++ b/pkg/provisioner/block/block.go
@@ -123,9 +123,9 @@ func (block *blockProvisioner) waitForVolumeAvailable(volumeID *string, timeout 
 
 }
 func volumeRoundingEnabled(param map[string]string) bool {
-	volumeRounding := true //default
+	volumeRounding := true // default
 	if volumeRoundingUpParam, ok := param[volumeRoundingUpEnabled]; ok {
-		if volumeRoundingUpParam == "false" {
+		if enabled, err := strconv.ParseBool(volumeRoundingUpParam); err == nil && !enabled {
 			volumeRounding = false
 		}
 	}

--- a/pkg/provisioner/block/block.go
+++ b/pkg/provisioner/block/block.go
@@ -120,6 +120,16 @@ func (block *blockProvisioner) waitForVolumeAvailable(volumeID *string, timeout 
 		}
 		return ready, nil
 	})
+
+}
+func volumeRoundingEnabled(param map[string]string) bool {
+	volumeRounding := true //default
+	if volumeRoundingUpParam, ok := param[volumeRoundingUpEnabled]; ok {
+		if volumeRoundingUpParam == "false" {
+			volumeRounding = false
+		}
+	}
+	return volumeRounding
 }
 
 func volumeRoundingEnabled(param map[string]string) bool {

--- a/pkg/provisioner/block/block.go
+++ b/pkg/provisioner/block/block.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -122,9 +123,9 @@ func (block *blockProvisioner) waitForVolumeAvailable(volumeID *string, timeout 
 }
 
 func volumeRoundingEnabled(param map[string]string) bool {
-	volumeRounding := true //default
+	volumeRounding := true // default
 	if volumeRoundingUpParam, ok := param[volumeRoundingUpEnabled]; ok {
-		if volumeRoundingUpParam == "false" {
+		if enabled, err := strconv.ParseBool(volumeRoundingUpParam); err == nil && !enabled {
 			volumeRounding = false
 		}
 	}


### PR DESCRIPTION
Add support for disabling volume roundup in the case a PVC is less than 50GB, via a parameters of a storage class. If a PVC is less than 50GB, it will fail. 