### PR TITLE
Set correct default provisioner name

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -93,7 +93,7 @@ func main() {
 	// Decides what type of provider to deploy, either block or fss
 	provisionerType := os.Getenv("PROVISIONER_TYPE")
 	if provisionerType == "" {
-		provisionerType = core.ProvisionerNameBlock
+		provisionerType = core.ProvisionerNameDefault
 	}
 
 	glog.Infof("Starting volume provisioner in %s mode", provisionerType)


### PR DESCRIPTION
Trivial, but makes the provided storage class files work. 

If no provisioner type is set, as is the case for our distributed image the name of the provisioner is set to oracle.com/oci-block; which doesn't match up with what is set in our provided storage class configuration "oracle.com/oci". 