### PR TITLE
Idempotent FSS Provision

### DIFF
--- a/pkg/oci/client/client.go
+++ b/pkg/oci/client/client.go
@@ -65,9 +65,13 @@ type Identity interface {
 // FSS specifies the subset of the OCI core API utilised by the provisioner.
 type FSS interface {
 	CreateFileSystem(ctx context.Context, request filestorage.CreateFileSystemRequest) (response filestorage.CreateFileSystemResponse, err error)
+	GetFileSystem(ctx context.Context, request filestorage.GetFileSystemRequest) (response filestorage.GetFileSystemResponse, err error)
+	ListFileSystems(ctx context.Context, request filestorage.ListFileSystemsRequest) (response filestorage.ListFileSystemsResponse, err error)
 	DeleteFileSystem(ctx context.Context, request filestorage.DeleteFileSystemRequest) (response filestorage.DeleteFileSystemResponse, err error)
 	CreateMountTarget(ctx context.Context, request filestorage.CreateMountTargetRequest) (response filestorage.CreateMountTargetResponse, err error)
 	CreateExport(ctx context.Context, request filestorage.CreateExportRequest) (response filestorage.CreateExportResponse, err error)
+	ListExports(ctx context.Context, request filestorage.ListExportsRequest) (response filestorage.ListExportsResponse, err error)
+	GetExport(ctx context.Context, request filestorage.GetExportRequest) (response filestorage.GetExportResponse, err error)
 	DeleteExport(ctx context.Context, request filestorage.DeleteExportRequest) (response filestorage.DeleteExportResponse, err error)
 	GetMountTarget(ctx context.Context, request filestorage.GetMountTargetRequest) (response filestorage.GetMountTargetResponse, err error)
 	ListMountTargets(ctx context.Context, request filestorage.ListMountTargetsRequest) (response filestorage.ListMountTargetsResponse, err error)

--- a/pkg/oci/client/client.go
+++ b/pkg/oci/client/client.go
@@ -62,19 +62,19 @@ type Identity interface {
 	ListAvailabilityDomains(ctx context.Context, request identity.ListAvailabilityDomainsRequest) (response identity.ListAvailabilityDomainsResponse, err error)
 }
 
-// FSS specifies the subset of the OCI core API utilised by the provisioner.
+// FSS specifies the subset of the OCI filestorage API utilised by the provisioner.
 type FSS interface {
 	CreateFileSystem(ctx context.Context, request filestorage.CreateFileSystemRequest) (response filestorage.CreateFileSystemResponse, err error)
 	GetFileSystem(ctx context.Context, request filestorage.GetFileSystemRequest) (response filestorage.GetFileSystemResponse, err error)
 	ListFileSystems(ctx context.Context, request filestorage.ListFileSystemsRequest) (response filestorage.ListFileSystemsResponse, err error)
 	DeleteFileSystem(ctx context.Context, request filestorage.DeleteFileSystemRequest) (response filestorage.DeleteFileSystemResponse, err error)
-	CreateMountTarget(ctx context.Context, request filestorage.CreateMountTargetRequest) (response filestorage.CreateMountTargetResponse, err error)
+
 	CreateExport(ctx context.Context, request filestorage.CreateExportRequest) (response filestorage.CreateExportResponse, err error)
 	ListExports(ctx context.Context, request filestorage.ListExportsRequest) (response filestorage.ListExportsResponse, err error)
 	GetExport(ctx context.Context, request filestorage.GetExportRequest) (response filestorage.GetExportResponse, err error)
 	DeleteExport(ctx context.Context, request filestorage.DeleteExportRequest) (response filestorage.DeleteExportResponse, err error)
+
 	GetMountTarget(ctx context.Context, request filestorage.GetMountTargetRequest) (response filestorage.GetMountTargetResponse, err error)
-	ListMountTargets(ctx context.Context, request filestorage.ListMountTargetsRequest) (response filestorage.ListMountTargetsResponse, err error)
 }
 
 //VCN specifies the subset of the OCI core API utilised by the provisioner.

--- a/pkg/provisioner/fss/fss.go
+++ b/pkg/provisioner/fss/fss.go
@@ -89,7 +89,7 @@ func (fsp *filesystemProvisioner) awaitFileSystem(ctx context.Context, logger *z
 	logger.Infof("Waiting for FileSystem to be in lifecycle state %q", fss.FileSystemLifecycleStateActive)
 
 	var fs *fss.FileSystem
-	err := wait.Poll(defaultInterval, defaultTimeout, func() (bool, error) {
+	err := wait.PollImmediate(defaultInterval, defaultTimeout, func() (bool, error) {
 		logger.Debug("Polling FileSystem lifecycle state")
 
 		resp, err := fsp.client.FSS().GetFileSystem(ctx, fss.GetFileSystemRequest{
@@ -123,7 +123,7 @@ func (fsp *filesystemProvisioner) awaitMountTarget(ctx context.Context, logger *
 	logger.Infof("Waiting for MountTarget to be in lifecycle state %q", fss.MountTargetLifecycleStateActive)
 
 	var mt *fss.MountTarget
-	if err := wait.Poll(defaultInterval, defaultTimeout, func() (bool, error) {
+	if err := wait.PollImmediate(defaultInterval, defaultTimeout, func() (bool, error) {
 		logger.Debug("Polling MountTarget lifecycle state")
 
 		resp, err := fsp.client.FSS().GetMountTarget(ctx, fss.GetMountTargetRequest{MountTargetId: &id})
@@ -135,7 +135,7 @@ func (fsp *filesystemProvisioner) awaitMountTarget(ctx context.Context, logger *
 
 		switch state := resp.LifecycleState; state {
 		case fss.MountTargetLifecycleStateActive:
-			logger.Infof("Mount target is in lifecycle state %q")
+			logger.Infof("Mount target is in lifecycle state %q", state)
 			return true, nil
 		case fss.MountTargetLifecycleStateFailed,
 			fss.MountTargetLifecycleStateDeleting,
@@ -156,7 +156,7 @@ func (fsp *filesystemProvisioner) awaitExport(ctx context.Context, logger *zap.S
 	logger.Info("Waiting for Export to be in lifecycle state ACTIVE")
 
 	var export *fss.Export
-	if err := wait.Poll(defaultInterval, defaultTimeout, func() (bool, error) {
+	if err := wait.PollImmediate(defaultInterval, defaultTimeout, func() (bool, error) {
 		logger.Debug("Polling export lifecycle state")
 
 		resp, err := fsp.client.FSS().GetExport(ctx, fss.GetExportRequest{ExportId: &id})

--- a/pkg/provisioner/fss/fss.go
+++ b/pkg/provisioner/fss/fss.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"time"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,16 +37,24 @@ import (
 	"github.com/oracle/oci-volume-provisioner/pkg/oci/instancemeta"
 	"github.com/oracle/oci-volume-provisioner/pkg/provisioner"
 	"github.com/oracle/oci-volume-provisioner/pkg/provisioner/plugin"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
 	ociVolumeID = "volume.beta.kubernetes.io/oci-volume-id"
 	ociExportID = "volume.beta.kubernetes.io/oci-export-id"
 	fsType      = "fsType"
+
 	// SubnetID is the name of the parameter which holds the target subnet ocid.
 	SubnetID = "subnetId"
 	// MntTargetID is the name of the parameter which hold the target mount target ocid.
 	MntTargetID = "mntTargetId"
+)
+
+const (
+	defaultTimeout  = 5 * time.Minute
+	defaultInterval = 5 * time.Second
 )
 
 // filesystemProvisioner is the internal provisioner for OCI filesystem volumes
@@ -56,6 +65,11 @@ type filesystemProvisioner struct {
 }
 
 var _ plugin.ProvisionerPlugin = &filesystemProvisioner{}
+
+var (
+	errNoCandidateFound = errors.New("no candidate mount targets found")
+	errNotFound         = errors.New("not found")
+)
 
 // NewFilesystemProvisioner creates a new file system provisioner that creates
 // filesystems using OCI File System Service.
@@ -72,9 +86,6 @@ func NewFilesystemProvisioner(logger *zap.SugaredLogger, client client.Provision
 
 // getMountTargetFromID retrieves mountTarget from given mountTargetID
 func (fsp *filesystemProvisioner) getMountTargetFromID(ctx context.Context, mountTargetID string) (*filestorage.MountTarget, error) {
-	ctx, cancel := context.WithTimeout(ctx, fsp.client.Timeout())
-	defer cancel()
-
 	resp, err := fsp.client.FSS().GetMountTarget(ctx, filestorage.GetMountTargetRequest{
 		MountTargetId: &mountTargetID,
 	})
@@ -84,139 +95,290 @@ func (fsp *filesystemProvisioner) getMountTargetFromID(ctx context.Context, moun
 	return &resp.MountTarget, nil
 }
 
-// listAllMountTargets retrieves all available mount targets
-func (fsp *filesystemProvisioner) listAllMountTargets(ctx context.Context, ad string) ([]filestorage.MountTargetSummary, error) {
+// getCandidateMountTargetID retrieves all available mount targets.
+func (fsp *filesystemProvisioner) getCandidateMountTargetID(ctx context.Context, ad string) (string, error) {
 	var (
-		page         *string
-		mountTargets []filestorage.MountTargetSummary
+		page     *string
+		active   []*filestorage.MountTargetSummary
+		creating []*filestorage.MountTargetSummary
 	)
-	// Check if there already is a mount target in the existing compartment
 	for {
-		ctx, cancel := context.WithTimeout(ctx, fsp.client.Timeout())
-		defer cancel()
 		resp, err := fsp.client.FSS().ListMountTargets(ctx, filestorage.ListMountTargetsRequest{
 			AvailabilityDomain: &ad,
 			CompartmentId:      common.String(fsp.client.CompartmentOCID()),
 			Page:               page,
 		})
 		if err != nil {
-			return nil, err
+			return "", err
 		}
-		mountTargets = append(mountTargets, resp.Items...)
+		for _, mt := range resp.Items {
+			switch mt.LifecycleState {
+			case filestorage.MountTargetSummaryLifecycleStateActive:
+				active = append(active, &mt)
+			case filestorage.MountTargetSummaryLifecycleStateCreating:
+				creating = append(creating, &mt)
+			}
+		}
 		if page = resp.OpcNextPage; resp.OpcNextPage == nil {
 			break
 		}
 	}
-	return mountTargets, nil
+
+	var candidates []*filestorage.MountTargetSummary
+	if len(active) != 0 {
+		candidates = active
+	} else {
+		candidates = creating
+	}
+
+	if len(candidates) == 0 {
+		return "", nil
+	}
+
+	return *(candidates[rand.Int()%len(candidates)]).Id, nil
 }
 
-func (fsp *filesystemProvisioner) getOrCreateMountTarget(ctx context.Context, mtID string, ad string, subnetID string) (*filestorage.MountTarget, error) {
-	if mtID != "" {
-		// Mount target already specified in the configuration file, find it in the list of mount targets
-		return fsp.getMountTargetFromID(ctx, mtID)
-	}
-	mountTargets, err := fsp.listAllMountTargets(ctx, ad)
-	if err != nil {
-		return nil, err
-	}
-	if len(mountTargets) != 0 {
-		mntTargetSummary := mountTargets[rand.Int()%len(mountTargets)]
-		target, err := fsp.getMountTargetFromID(ctx, *mntTargetSummary.Id)
-		return target, err
-	}
-	ctx, cancel := context.WithTimeout(ctx, fsp.client.Timeout())
-	defer cancel()
-	mtDisplayName := common.String(fmt.Sprintf("%s%s", provisioner.GetPrefix(), "mnt"))
-	// Mount target not created, create a new one
-	fsp.logger.With("subnetId", subnetID, "mountTargetDisplayName", mtDisplayName).Info("Creating mount target.")
+func (fsp *filesystemProvisioner) createMountTarget(ctx context.Context, logger *zap.SugaredLogger, ad, subnetID string) (string, error) {
+	displayName := fmt.Sprintf("%s%s", provisioner.GetPrefix(), "mnt")
+
+	logger = logger.With("mountTargetDisplayName", displayName)
+	logger.Info("Creating mount target")
+
 	resp, err := fsp.client.FSS().CreateMountTarget(ctx, filestorage.CreateMountTargetRequest{
 		CreateMountTargetDetails: filestorage.CreateMountTargetDetails{
 			AvailabilityDomain: &ad,
 			SubnetId:           &subnetID,
 			CompartmentId:      common.String(fsp.client.CompartmentOCID()),
-			DisplayName:        mtDisplayName,
+			DisplayName:        &displayName,
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return *resp.MountTarget.Id, nil
+}
+
+func (fsp *filesystemProvisioner) getOrCreateMountTarget(ctx context.Context, mtID string, ad string, subnetID string) (*filestorage.MountTarget, error) {
+	logger := fsp.logger.With("subnetId", subnetID)
+
+	if mtID != "" {
+		return fsp.awaitMountTarget(ctx, logger, mtID)
+	}
+
+	var err error
+	mtID, err = fsp.getCandidateMountTargetID(ctx, ad)
+	if err != nil {
+		if err != errNoCandidateFound {
+			return nil, err
+		}
+
+		mtID, err = fsp.createMountTarget(ctx, logger, ad, subnetID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return fsp.awaitMountTarget(ctx, logger, mtID)
+}
+
+func (fsp *filesystemProvisioner) awaitFileSystem(ctx context.Context, logger *zap.SugaredLogger, id string) (*filestorage.FileSystem, error) {
+	var fs *filestorage.FileSystem
+	err := wait.Poll(defaultInterval, defaultTimeout, func() (bool, error) {
+		logger.Debug("Polling file system lifecycle state")
+
+		resp, err := fsp.client.FSS().GetFileSystem(ctx, filestorage.GetFileSystemRequest{
+			FileSystemId: &id,
+		})
+
+		if err != nil {
+			return false, err
+		}
+
+		switch resp.LifecycleState {
+		case filestorage.FileSystemLifecycleStateActive:
+			fs = &resp.FileSystem
+			logger.Infof("File system is in lifecycle state %s", resp.LifecycleState)
+			return true, nil
+		default:
+			logger.Debugf("File system is in lifecycle state %s", resp.FileSystem.LifecycleState)
+			return false, nil
+		}
+	})
+
+	return fs, err
+}
+
+func (fsp *filesystemProvisioner) awaitMountTarget(ctx context.Context, logger *zap.SugaredLogger, id string) (*filestorage.MountTarget, error) {
+	logger.Info("Waiting for MountTarget to be in lifecycle state ACTIVE")
+
+	var mt *filestorage.MountTarget
+	if err := wait.Poll(defaultInterval, defaultTimeout, func() (bool, error) {
+		logger.Debug("Polling mount target lifecycle state")
+
+		resp, err := fsp.client.FSS().GetMountTarget(ctx, filestorage.GetMountTargetRequest{MountTargetId: &id})
+		if err != nil {
+			return false, err
+		}
+
+		mt = &resp.MountTarget
+
+		switch resp.LifecycleState {
+		case filestorage.MountTargetLifecycleStateActive:
+			logger.Info("Mount target is in lifecycle state ACTIVE")
+			return true, nil
+		case filestorage.MountTargetLifecycleStateFailed:
+			logger.Error("Mount target is in lifecycle state FAILED")
+			return false, fmt.Errorf("mount target %q is in lifecycle state FAILED", *resp.MountTarget.Id)
+		default:
+			logger.Debugf("Mount target is in lifecycle state %s", resp.MountTarget.LifecycleState)
+			return false, nil
+		}
+	}); err != nil {
+		return nil, err
+	}
+	return mt, nil
+}
+
+func (fsp *filesystemProvisioner) awaitExport(ctx context.Context, logger *zap.SugaredLogger, id string) (*filestorage.Export, error) {
+	logger.Info("Waiting for Export to be in lifecycle state ACTIVE")
+
+	var export *filestorage.Export
+	if err := wait.Poll(defaultInterval, defaultTimeout, func() (bool, error) {
+		logger.Debug("Polling export lifecycle state")
+
+		resp, err := fsp.client.FSS().GetExport(ctx, filestorage.GetExportRequest{ExportId: &id})
+		if err != nil {
+			return false, err
+		}
+
+		export = &resp.Export
+
+		switch state := resp.LifecycleState; state {
+		case filestorage.ExportLifecycleStateActive:
+			logger.Info("Export is in lifecycle state ACTIVE")
+			return true, nil
+		case filestorage.ExportLifecycleStateDeleting, filestorage.ExportLifecycleStateDeleted:
+			logger.Errorf("Export is in lifecycle state %s", state)
+			return false, fmt.Errorf("export %q is in lifecycle state %s", *resp.Export.Id, state)
+		default:
+			logger.Debugf("Export is in lifecycle state %s", resp.Export.LifecycleState)
+			return false, nil
+		}
+	}); err != nil {
+		return nil, err
+	}
+	return export, nil
+}
+
+func (fsp *filesystemProvisioner) getFileSystemByDisplayName(ctx context.Context, ad, displayName string) (*filestorage.FileSystemSummary, error) {
+	resp, err := fsp.client.FSS().ListFileSystems(ctx, filestorage.ListFileSystemsRequest{
+		CompartmentId:      common.String(fsp.client.CompartmentOCID()),
+		AvailabilityDomain: &ad,
+		DisplayName:        &displayName,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(resp.Items) > 1 {
+		return nil, errors.Errorf("found more than one file system with display name %q", displayName)
+	}
+
+	if len(resp.Items) == 1 {
+		return &resp.Items[0], nil
+	}
+
+	return nil, errNotFound
+}
+
+func (fsp *filesystemProvisioner) getOrCreateFileSystem(ctx context.Context, logger *zap.SugaredLogger, ad, displayName string) (*filestorage.FileSystem, error) {
+	fs, err := fsp.getFileSystemByDisplayName(ctx, ad, displayName)
+	if err != nil && err != errNotFound {
+		return nil, err
+	}
+	if fs != nil {
+		return fsp.awaitFileSystem(ctx, logger, *fs.Id)
+	}
+
+	resp, err := fsp.client.FSS().CreateFileSystem(ctx, filestorage.CreateFileSystemRequest{
+		CreateFileSystemDetails: filestorage.CreateFileSystemDetails{
+			AvailabilityDomain: &ad,
+			CompartmentId:      common.String(fsp.client.CompartmentOCID()),
+			DisplayName:        &displayName,
 		},
 	})
 	if err != nil {
 		return nil, err
 	}
-	return &resp.MountTarget, nil
+
+	logger.With("fileSystemID", *resp.FileSystem.Id).Info("Created filesystem")
+
+	return fsp.awaitFileSystem(ctx, logger, *resp.FileSystem.Id)
+}
+
+// findExport looks for an existing export with the same filesystem ID, export set ID, and path.
+// NOTE: No two non-'DELETED' export resources in the same export set can reference the same file system.
+func (fsp *filesystemProvisioner) findExport(ctx context.Context, fsID, exportSetID string) (*filestorage.ExportSummary, error) {
+	var page *string
+	for {
+		resp, err := fsp.client.FSS().ListExports(ctx, filestorage.ListExportsRequest{
+			CompartmentId: common.String(fsp.client.CompartmentOCID()),
+			FileSystemId:  &fsID,
+			ExportSetId:   &exportSetID,
+			Page:          page,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, export := range resp.Items {
+			if export.LifecycleState == filestorage.ExportSummaryLifecycleStateCreating ||
+				export.LifecycleState == filestorage.ExportSummaryLifecycleStateActive {
+				return &export, nil
+			}
+		}
+		if page = resp.OpcNextPage; resp.OpcNextPage == nil {
+			break
+		}
+	}
+
+	return nil, errNotFound
+}
+
+func (fsp *filesystemProvisioner) getOrCreateExport(ctx context.Context, logger *zap.SugaredLogger, fsID, exportSetID string) (*filestorage.Export, error) {
+	export, err := fsp.findExport(ctx, fsID, exportSetID)
+	if err != nil && err != errNotFound {
+		return nil, err
+	}
+	if export != nil {
+		return fsp.awaitExport(ctx, logger, *export.Id)
+	}
+
+	path := "/" + fsID
+
+	// If export doesn't already exist create it.
+	resp, err := fsp.client.FSS().CreateExport(ctx, filestorage.CreateExportRequest{
+		CreateExportDetails: filestorage.CreateExportDetails{
+			ExportSetId:  &exportSetID,
+			FileSystemId: &fsID,
+			Path:         &path,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	logger.With("exportID", *resp.Export.Id).Info("Created Export")
+	return fsp.awaitExport(ctx, logger, *resp.Export.Id)
 }
 
 func (fsp *filesystemProvisioner) Provision(options controller.VolumeOptions, ad *identity.AvailabilityDomain) (*v1.PersistentVolume, error) {
 	ctx := context.Background()
-	fsDisplayName := common.String(fmt.Sprintf("%s%s", provisioner.GetPrefix(), options.PVC.Name))
+	fsDisplayName := fmt.Sprintf("%s%s", provisioner.GetPrefix(), options.PVC.UID)
 	logger := fsp.logger.With(
 		"availabilityDomain", ad,
 		"fileSystemDisplayName", fsDisplayName,
 	)
-	// Create the FileSystem.
-	logger.Info("Creating FileSystem")
-	var fsID string
-	{
-		ctx, cancel := context.WithTimeout(ctx, fsp.client.Timeout())
-		defer cancel()
-		resp, err := fsp.client.FSS().CreateFileSystem(ctx, filestorage.CreateFileSystemRequest{
-			CreateFileSystemDetails: filestorage.CreateFileSystemDetails{
-				AvailabilityDomain: ad.Name,
-				CompartmentId:      common.String(fsp.client.CompartmentOCID()),
-				DisplayName:        fsDisplayName,
-			},
-		})
-		if err != nil {
-			return nil, err
-		}
-		fsID = *resp.FileSystem.Id
-	}
-	logger = logger.With("fileSystemID", fsID)
-
-	target, err := fsp.getOrCreateMountTarget(ctx, options.Parameters[MntTargetID], *ad.Name, options.Parameters[SubnetID])
-	if err != nil {
-		logger.With(zap.Error(err)).Error("Failed to retrieve mount target.")
-		return nil, err
-	}
-
-	logger.Info("Creating export set.")
-	// Create the ExportSet.
-	var exportSetID string
-	{
-		ctx, cancel := context.WithTimeout(ctx, fsp.client.Timeout())
-		defer cancel()
-		resp, err := fsp.client.FSS().CreateExport(ctx, filestorage.CreateExportRequest{
-			CreateExportDetails: filestorage.CreateExportDetails{
-				ExportSetId:  target.ExportSetId,
-				FileSystemId: &fsID,
-				Path:         common.String("/" + fsID),
-			},
-		})
-		if err != nil {
-			logger.With(zap.Error(err)).Error("Failed to create export.")
-			return nil, err
-		}
-		exportSetID = *resp.Export.Id
-		logger = logger.With("exportSetID", exportSetID)
-	}
-
-	if len(target.PrivateIpIds) == 0 {
-		logger.With("targetID", *target.Id).Error("Could not find any Private IPs for Mount Target.")
-		return nil, errors.Errorf("failed to find server IDs associated with the Mount Target with OCID %q", *target.Id)
-	}
-
-	// Get PrivateIP.
-	var serverIP string
-	{
-		ctx, cancel := context.WithTimeout(ctx, fsp.client.Timeout())
-		defer cancel()
-		id := target.PrivateIpIds[rand.Int()%len(target.PrivateIpIds)]
-		getPrivateIPResponse, err := fsp.client.VCN().GetPrivateIp(ctx, core.GetPrivateIpRequest{
-			PrivateIpId: &id,
-		})
-		if err != nil {
-			logger.With(zap.Error(err), "privateIPID", id).Errorf("Failed to retrieve IP address for mount target privateIpID=%q: %v", id, err)
-			return nil, err
-		}
-		serverIP = *getPrivateIPResponse.PrivateIp.IpAddress
-	}
 
 	region, ok := os.LookupEnv("OCI_SHORT_REGION")
 	if !ok {
@@ -227,32 +389,79 @@ func (fsp *filesystemProvisioner) Provision(options controller.VolumeOptions, ad
 		region = metadata.Region
 	}
 
+	target, err := fsp.getOrCreateMountTarget(ctx, options.Parameters[MntTargetID], *ad.Name, options.Parameters[SubnetID])
+	if err != nil {
+		logger.With(zap.Error(err)).Error("Failed to retrieve mount target")
+		return nil, err
+	}
+
+	logger = logger.With("mountTargetID", *target.Id)
+
+	if len(target.PrivateIpIds) == 0 {
+		logger.Error("Failed to find private IP IDs associated with the Mount Target")
+		return nil, errors.Errorf("mount target has no private IP IDs")
+	}
+
+	if target.ExportSetId == nil {
+		logger.Error("Mount target has no export set associated with it")
+		return nil, errors.Errorf("mount target has no export set associated with it")
+	}
+
+	// Randomnly select IP address associated with the mount target to use
+	// for attachment.
+	var serverIP string
+	{
+		id := target.PrivateIpIds[rand.Int()%len(target.PrivateIpIds)]
+		getPrivateIPResponse, err := fsp.client.VCN().GetPrivateIp(ctx, core.GetPrivateIpRequest{PrivateIpId: &id})
+		if err != nil {
+			logger.With(zap.Error(err), "privateIPID", id).Error("Failed to retrieve IP address for mount target")
+			return nil, err
+		}
+		serverIP = *getPrivateIPResponse.PrivateIp.IpAddress
+	}
+
 	logger.With("privateIP", serverIP).Info("Selected Mount Target Private IP.")
+
+	logger.Info("Creating FileSystem")
+	var fsID string
+	{
+		fs, err := fsp.getOrCreateFileSystem(ctx, logger, *ad.Name, fsDisplayName)
+		if err != nil {
+			return nil, err
+		}
+		fsID = *fs.Id
+
+		logger = logger.With("fileSystemID", fsID)
+	}
+
+	logger.Info("Creating export set")
+	export, err := fsp.getOrCreateExport(ctx, logger, fsID, *target.ExportSetId)
+	if err != nil {
+		logger.With(zap.Error(err)).Error("Failed to create export.")
+		return nil, err
+	}
 
 	return &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fsID,
 			Annotations: map[string]string{
 				ociVolumeID: fsID,
-				ociExportID: exportSetID,
+				ociExportID: *export.Id,
 			},
-			Labels: map[string]string{
-				plugin.LabelZoneRegion: region,
-			},
+			Labels: map[string]string{plugin.LabelZoneRegion: region},
 		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeReclaimPolicy: options.PersistentVolumeReclaimPolicy,
 			AccessModes:                   options.PVC.Spec.AccessModes,
-			//FIXME: fs storage doesn't enforce quota, capacity is meaningless here.
+			//NOTE: fs storage doesn't enforce quota, capacity is meaningless here.
 			Capacity: v1.ResourceList{
 				v1.ResourceName(v1.ResourceStorage): options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)],
 			},
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				NFS: &v1.NFSVolumeSource{
-					// Randomnly select IP address associated with the mount target to use for attachment
 					Server:   serverIP,
-					Path:     "/" + fsID,
-					ReadOnly: false,
+					Path:     *export.Path,
+					ReadOnly: false, // TODO: Should this be based on the AccessModes?
 				},
 			},
 			MountOptions: options.MountOptions,
@@ -278,21 +487,16 @@ func (fsp *filesystemProvisioner) Delete(volume *v1.PersistentVolume) error {
 		"exportOCID", exportID,
 	)
 
-	logger.Info("Deleting export.")
-	ctx, cancel := context.WithTimeout(ctx, fsp.client.Timeout())
-	defer cancel()
+	logger.Info("Deleting export")
 	if _, err := fsp.client.FSS().DeleteExport(ctx, filestorage.DeleteExportRequest{
 		ExportId: &exportID,
 	}); err != nil {
 		if !provisioner.IsNotFound(err) {
-			logger.With(zap.Error(err)).Error("Failed to delete export.")
+			logger.With(zap.Error(err)).Error("Failed to delete export")
 			return err
 		}
-		logger.With(zap.Error(err)).Info("ExportID not found. Unable to delete it.")
+		logger.With(zap.Error(err)).Info("ExportID not found. Unable to delete it")
 	}
-
-	ctx, cancel = context.WithTimeout(ctx, fsp.client.Timeout())
-	defer cancel()
 
 	logger.Info("Deleting File System.")
 
@@ -303,7 +507,7 @@ func (fsp *filesystemProvisioner) Delete(volume *v1.PersistentVolume) error {
 		if !provisioner.IsNotFound(err) {
 			return err
 		}
-		logger.Info("File System not found. Unable to delete it.")
+		logger.Info("File System not found. Unable to delete it")
 	}
 	return nil
 }

--- a/pkg/provisioner/fss/fss_test.go
+++ b/pkg/provisioner/fss/fss_test.go
@@ -48,11 +48,11 @@ func TestListAllMountTargets(t *testing.T) {
 	// test listing all mount targets
 	var ctx = context.Background()
 	fss := filesystemProvisioner{client: provisioner.NewClientProvisioner(nil, nil)}
-	resp, err := fss.listAllMountTargets(ctx, "adOCID")
+	id, err := fss.getCandidateMountTargetID(ctx, "adOCID")
 	if err != nil {
 		t.Fatalf("Failed to retrieve list mount targets: %v", err)
 	}
-	if !reflect.DeepEqual(resp, provisioner.MountTargetItems) {
+	if id != "dummyMountTargetID" {
 		t.Fatalf("Incorrect response for listing mount targets")
 	}
 }
@@ -72,6 +72,7 @@ func TestGetOrCreateMountTarget(t *testing.T) {
 }
 
 func TestCreateVolumeWithFSS(t *testing.T) {
+	t.Skip("needs mock filling out")
 	// test creating a volume on a file system storage
 	options := controller.VolumeOptions{
 		PVName: "dummyVolumeOptions",

--- a/pkg/provisioner/fss/fss_test.go
+++ b/pkg/provisioner/fss/fss_test.go
@@ -15,8 +15,6 @@
 package fss
 
 import (
-	"context"
-	"reflect"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -27,49 +25,8 @@ import (
 	"github.com/oracle/oci-go-sdk/identity"
 	"go.uber.org/zap"
 
-	"github.com/oracle/oci-volume-provisioner/pkg/oci/instancemeta"
 	"github.com/oracle/oci-volume-provisioner/pkg/provisioner"
 )
-
-func TestGetMountTargetFromID(t *testing.T) {
-	// test retrieving a mount target from given ID
-	var ctx = context.Background()
-	fss := filesystemProvisioner{client: provisioner.NewClientProvisioner(nil, nil)}
-	resp, err := fss.getMountTargetFromID(ctx, "mtOCID")
-	if err != nil {
-		t.Fatalf("Failed to retrieve mount target from ID: %v", err)
-	}
-	if !reflect.DeepEqual(resp.PrivateIpIds, provisioner.ServerIPs) {
-		t.Fatalf("Incorrect response for retrieving mount target from ID")
-	}
-}
-
-func TestListAllMountTargets(t *testing.T) {
-	// test listing all mount targets
-	var ctx = context.Background()
-	fss := filesystemProvisioner{client: provisioner.NewClientProvisioner(nil, nil)}
-	id, err := fss.getCandidateMountTargetID(ctx, "adOCID")
-	if err != nil {
-		t.Fatalf("Failed to retrieve list mount targets: %v", err)
-	}
-	if id != "dummyMountTargetID" {
-		t.Fatalf("Incorrect response for listing mount targets")
-	}
-}
-
-func TestGetOrCreateMountTarget(t *testing.T) {
-	// test get or create mount target
-	var ctx = context.Background()
-	fss := filesystemProvisioner{client: provisioner.NewClientProvisioner(nil, nil), logger: zap.S()}
-	resp, err := fss.getOrCreateMountTarget(ctx, "", provisioner.NilListMountTargetsADID, "subnetID")
-	if err != nil {
-		t.Fatalf("Failed to retrieve or create mount target: %v", err)
-	}
-	if *resp.Id != provisioner.CreatedMountTargetID {
-		t.Fatalf("Failed to create mount target")
-	}
-
-}
 
 func TestCreateVolumeWithFSS(t *testing.T) {
 	t.Skip("needs mock filling out")
@@ -83,10 +40,8 @@ func TestCreateVolumeWithFSS(t *testing.T) {
 	fss := filesystemProvisioner{
 		client: provisioner.NewClientProvisioner(nil, nil),
 		logger: zap.S(),
-		metadata: instancemeta.NewMock(&instancemeta.InstanceMetadata{
-			CompartmentOCID: "",
-			Region:          "phx",
-		})}
+		region: "phx",
+	}
 	_, err := fss.Provision(options, &ad)
 	if err != nil {
 		t.Fatalf("Failed to provision volume from fss storage: %v", err)

--- a/pkg/provisioner/fss/fss_test.go
+++ b/pkg/provisioner/fss/fss_test.go
@@ -23,26 +23,32 @@ import (
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
 	"github.com/oracle/oci-go-sdk/common"
 	"github.com/oracle/oci-go-sdk/identity"
-	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/oracle/oci-volume-provisioner/pkg/provisioner"
 )
 
 func TestCreateVolumeWithFSS(t *testing.T) {
-	t.Skip("needs mock filling out")
-	// test creating a volume on a file system storage
-	options := controller.VolumeOptions{
-		PVName: "dummyVolumeOptions",
-		PVC: &v1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{},
-		}}
-	ad := identity.AvailabilityDomain{Name: common.String("dummyAdName"), CompartmentId: common.String("dummyCompartmentId")}
-	fss := filesystemProvisioner{
+	fsp := filesystemProvisioner{
 		client: provisioner.NewClientProvisioner(nil, nil),
-		logger: zap.S(),
+		logger: zaptest.NewLogger(t).Sugar(),
 		region: "phx",
 	}
-	_, err := fss.Provision(options, &ad)
+	_, err := fsp.Provision(
+		controller.VolumeOptions{
+			PVName: "dummyVolumeOptions",
+			PVC: &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: "my-uid",
+				},
+			},
+			Parameters: map[string]string{MntTargetID: "dummyMountTargetID"},
+		},
+		&identity.AvailabilityDomain{
+			Name:          common.String("dummyAdName"),
+			CompartmentId: common.String("dummyCompartmentId"),
+		},
+	)
 	if err != nil {
 		t.Fatalf("Failed to provision volume from fss storage: %v", err)
 	}

--- a/pkg/provisioner/mock_interfaces.go
+++ b/pkg/provisioner/mock_interfaces.go
@@ -30,6 +30,7 @@ var (
 	VolumeBackupID = "dummyVolumeBackupId"
 	fileSystemID   = "dummyFileSystemId"
 	exportID       = "dummyExportID"
+	exportSetID    = "dummyExportSetID"
 	// NilListMountTargetsADID lists no mount targets for the given AD
 	NilListMountTargetsADID = "dummyNilListMountTargetsForADID"
 	mountTargetID           = "dummyMountTargetID"
@@ -37,14 +38,7 @@ var (
 	CreatedMountTargetID = "dummyCreatedMountTargetID"
 	// ServerIPs address for mount target
 	ServerIPs = []string{"dummyServerIP"}
-	// MountTargetItems retrieving during listing
-	MountTargetItems = []filestorage.MountTargetSummary{{
-		LifecycleState: filestorage.MountTargetSummaryLifecycleStateActive,
-		Id:             &mountTargetID,
-	}}
-	// EmptyMountTargetItems retrieving during listing
-	EmptyMountTargetItems = []filestorage.MountTargetSummary{}
-	privateIP             = "127.0.0.1"
+	privateIP = "127.0.0.1"
 )
 
 // MockBlockStorageClient mocks BlockStorage client implementation
@@ -75,11 +69,10 @@ func (c *MockBlockStorageClient) GetVolume(ctx context.Context, request core.Get
 	}, nil
 }
 
-// MockFileStorageClient mocks FileStorage client implementation
-type MockFileStorageClient struct {
-}
+// MockFileStorageClient mocks FileStorage client implementation.
+type MockFileStorageClient struct{}
 
-// CreateFileSystem mocks the FileStorage CreateFileSystem implementation
+// CreateFileSystem mocks the FileStorage CreateFileSystem implementation.
 func (c *MockFileStorageClient) CreateFileSystem(ctx context.Context, request filestorage.CreateFileSystemRequest) (response filestorage.CreateFileSystemResponse, err error) {
 	return filestorage.CreateFileSystemResponse{
 		FileSystem: filestorage.FileSystem{
@@ -88,11 +81,11 @@ func (c *MockFileStorageClient) CreateFileSystem(ctx context.Context, request fi
 	}, nil
 }
 
-// GetFileSystem mocks the FileStorage GetFileSystem implementation
+// GetFileSystem mocks the FileStorage GetFileSystem implementation.
 func (c *MockFileStorageClient) GetFileSystem(ctx context.Context, request filestorage.GetFileSystemRequest) (response filestorage.GetFileSystemResponse, err error) {
 	return filestorage.GetFileSystemResponse{
 		FileSystem: filestorage.FileSystem{
-			Id:             common.String(fileSystemID),
+			Id:             request.FileSystemId,
 			LifecycleState: filestorage.FileSystemLifecycleStateActive,
 		},
 	}, nil
@@ -100,7 +93,13 @@ func (c *MockFileStorageClient) GetFileSystem(ctx context.Context, request files
 
 // ListFileSystems mocks the FileStorage ListFileSystems implementation.
 func (c *MockFileStorageClient) ListFileSystems(ctx context.Context, request filestorage.ListFileSystemsRequest) (response filestorage.ListFileSystemsResponse, err error) {
-	return filestorage.ListFileSystemsResponse{}, nil
+	return filestorage.ListFileSystemsResponse{
+		Items: []filestorage.FileSystemSummary{{
+			Id:             common.String(fileSystemID),
+			DisplayName:    request.DisplayName,
+			LifecycleState: filestorage.FileSystemSummaryLifecycleStateActive,
+		}},
+	}, nil
 }
 
 // DeleteFileSystem mocks the FileStorage DeleteFileSystem implementation
@@ -119,26 +118,32 @@ func (c *MockFileStorageClient) CreateExport(ctx context.Context, request filest
 
 // GetExport mocks the FileStorage CreateExport implementation.
 func (c *MockFileStorageClient) GetExport(ctx context.Context, request filestorage.GetExportRequest) (response filestorage.GetExportResponse, err error) {
-	return filestorage.GetExportResponse{}, nil
+	return filestorage.GetExportResponse{
+		Export: filestorage.Export{
+			Id:             common.String(exportID),
+			FileSystemId:   &fileSystemID,
+			ExportSetId:    &exportSetID,
+			LifecycleState: filestorage.ExportLifecycleStateActive,
+			Path:           common.String("/" + fileSystemID),
+		},
+	}, nil
 }
 
 // ListExports mocks the FileStorage ListExports implementation.
 func (c *MockFileStorageClient) ListExports(ctx context.Context, request filestorage.ListExportsRequest) (response filestorage.ListExportsResponse, err error) {
-	return filestorage.ListExportsResponse{}, nil
+	return filestorage.ListExportsResponse{
+		Items: []filestorage.ExportSummary{{
+			Id:             common.String(exportID),
+			ExportSetId:    request.ExportSetId,
+			FileSystemId:   request.FileSystemId,
+			LifecycleState: filestorage.ExportSummaryLifecycleStateActive,
+		}},
+	}, nil
 }
 
 // DeleteExport mocks the FileStorage DeleteExport implementation
 func (c *MockFileStorageClient) DeleteExport(ctx context.Context, request filestorage.DeleteExportRequest) (response filestorage.DeleteExportResponse, err error) {
 	return filestorage.DeleteExportResponse{}, nil
-}
-
-// CreateMountTarget mocks the FileStorage CreateMountTarget implementation
-func (c *MockFileStorageClient) CreateMountTarget(ctx context.Context, request filestorage.CreateMountTargetRequest) (response filestorage.CreateMountTargetResponse, err error) {
-	return filestorage.CreateMountTargetResponse{
-		MountTarget: filestorage.MountTarget{
-			PrivateIpIds: ServerIPs,
-			Id:           &CreatedMountTargetID},
-	}, nil
 }
 
 // GetMountTarget mocks the FileStorage GetMountTarget implementation
@@ -147,16 +152,10 @@ func (c *MockFileStorageClient) GetMountTarget(ctx context.Context, request file
 		MountTarget: filestorage.MountTarget{
 			PrivateIpIds:   ServerIPs,
 			Id:             &CreatedMountTargetID,
-			LifecycleState: filestorage.MountTargetLifecycleStateActive},
+			LifecycleState: filestorage.MountTargetLifecycleStateActive,
+			ExportSetId:    &exportSetID,
+		},
 	}, nil
-}
-
-// ListMountTargets mocks the FileStorage ListMountTargets implementation
-func (c *MockFileStorageClient) ListMountTargets(ctx context.Context, request filestorage.ListMountTargetsRequest) (response filestorage.ListMountTargetsResponse, err error) {
-	if *request.AvailabilityDomain == NilListMountTargetsADID {
-		return filestorage.ListMountTargetsResponse{Items: EmptyMountTargetItems}, nil
-	}
-	return filestorage.ListMountTargetsResponse{Items: MountTargetItems}, nil
 }
 
 // MockVirtualNetworkClient mocks VirtualNetwork client implementation
@@ -165,7 +164,11 @@ type MockVirtualNetworkClient struct {
 
 // GetPrivateIp mocks the VirtualNetwork GetPrivateIp implementation
 func (c *MockVirtualNetworkClient) GetPrivateIp(ctx context.Context, request core.GetPrivateIpRequest) (response core.GetPrivateIpResponse, err error) {
-	return core.GetPrivateIpResponse{PrivateIp: core.PrivateIp{IpAddress: common.String(privateIP)}}, nil
+	return core.GetPrivateIpResponse{
+		PrivateIp: core.PrivateIp{
+			IpAddress: common.String(privateIP),
+		},
+	}, nil
 }
 
 // MockIdentityClient mocks identity client structure

--- a/pkg/provisioner/mock_interfaces.go
+++ b/pkg/provisioner/mock_interfaces.go
@@ -38,7 +38,10 @@ var (
 	// ServerIPs address for mount target
 	ServerIPs = []string{"dummyServerIP"}
 	// MountTargetItems retrieving during listing
-	MountTargetItems = []filestorage.MountTargetSummary{filestorage.MountTargetSummary{Id: &mountTargetID}}
+	MountTargetItems = []filestorage.MountTargetSummary{{
+		LifecycleState: filestorage.MountTargetSummaryLifecycleStateActive,
+		Id:             &mountTargetID,
+	}}
 	// EmptyMountTargetItems retrieving during listing
 	EmptyMountTargetItems = []filestorage.MountTargetSummary{}
 	privateIP             = "127.0.0.1"
@@ -51,7 +54,11 @@ type MockBlockStorageClient struct {
 
 // CreateVolume mocks the BlockStorage CreateVolume implementation
 func (c *MockBlockStorageClient) CreateVolume(ctx context.Context, request core.CreateVolumeRequest) (response core.CreateVolumeResponse, err error) {
-	return core.CreateVolumeResponse{Volume: core.Volume{Id: common.String(VolumeBackupID)}}, nil
+	return core.CreateVolumeResponse{
+		Volume: core.Volume{
+			Id: common.String(VolumeBackupID),
+		},
+	}, nil
 }
 
 // DeleteVolume mocks the BlockStorage DeleteVolume implementation
@@ -61,7 +68,11 @@ func (c *MockBlockStorageClient) DeleteVolume(ctx context.Context, request core.
 
 // GetVolume mocks the BlockStorage GetVolume implementation
 func (c *MockBlockStorageClient) GetVolume(ctx context.Context, request core.GetVolumeRequest) (response core.GetVolumeResponse, err error) {
-	return core.GetVolumeResponse{Volume: core.Volume{LifecycleState: c.VolumeState}}, nil
+	return core.GetVolumeResponse{
+		Volume: core.Volume{
+			LifecycleState: c.VolumeState,
+		},
+	}, nil
 }
 
 // MockFileStorageClient mocks FileStorage client implementation
@@ -70,7 +81,26 @@ type MockFileStorageClient struct {
 
 // CreateFileSystem mocks the FileStorage CreateFileSystem implementation
 func (c *MockFileStorageClient) CreateFileSystem(ctx context.Context, request filestorage.CreateFileSystemRequest) (response filestorage.CreateFileSystemResponse, err error) {
-	return filestorage.CreateFileSystemResponse{FileSystem: filestorage.FileSystem{Id: common.String(fileSystemID)}}, nil
+	return filestorage.CreateFileSystemResponse{
+		FileSystem: filestorage.FileSystem{
+			Id: common.String(fileSystemID),
+		},
+	}, nil
+}
+
+// GetFileSystem mocks the FileStorage GetFileSystem implementation
+func (c *MockFileStorageClient) GetFileSystem(ctx context.Context, request filestorage.GetFileSystemRequest) (response filestorage.GetFileSystemResponse, err error) {
+	return filestorage.GetFileSystemResponse{
+		FileSystem: filestorage.FileSystem{
+			Id:             common.String(fileSystemID),
+			LifecycleState: filestorage.FileSystemLifecycleStateActive,
+		},
+	}, nil
+}
+
+// ListFileSystems mocks the FileStorage ListFileSystems implementation.
+func (c *MockFileStorageClient) ListFileSystems(ctx context.Context, request filestorage.ListFileSystemsRequest) (response filestorage.ListFileSystemsResponse, err error) {
+	return filestorage.ListFileSystemsResponse{}, nil
 }
 
 // DeleteFileSystem mocks the FileStorage DeleteFileSystem implementation
@@ -80,7 +110,21 @@ func (c *MockFileStorageClient) DeleteFileSystem(ctx context.Context, request fi
 
 // CreateExport mocks the FileStorage CreateExport implementation
 func (c *MockFileStorageClient) CreateExport(ctx context.Context, request filestorage.CreateExportRequest) (response filestorage.CreateExportResponse, err error) {
-	return filestorage.CreateExportResponse{Export: filestorage.Export{Id: common.String(exportID)}}, nil
+	return filestorage.CreateExportResponse{
+		Export: filestorage.Export{
+			Id: common.String(exportID),
+		},
+	}, nil
+}
+
+// GetExport mocks the FileStorage CreateExport implementation.
+func (c *MockFileStorageClient) GetExport(ctx context.Context, request filestorage.GetExportRequest) (response filestorage.GetExportResponse, err error) {
+	return filestorage.GetExportResponse{}, nil
+}
+
+// ListExports mocks the FileStorage ListExports implementation.
+func (c *MockFileStorageClient) ListExports(ctx context.Context, request filestorage.ListExportsRequest) (response filestorage.ListExportsResponse, err error) {
+	return filestorage.ListExportsResponse{}, nil
 }
 
 // DeleteExport mocks the FileStorage DeleteExport implementation
@@ -90,12 +134,21 @@ func (c *MockFileStorageClient) DeleteExport(ctx context.Context, request filest
 
 // CreateMountTarget mocks the FileStorage CreateMountTarget implementation
 func (c *MockFileStorageClient) CreateMountTarget(ctx context.Context, request filestorage.CreateMountTargetRequest) (response filestorage.CreateMountTargetResponse, err error) {
-	return filestorage.CreateMountTargetResponse{MountTarget: filestorage.MountTarget{PrivateIpIds: ServerIPs, Id: &CreatedMountTargetID}}, nil
+	return filestorage.CreateMountTargetResponse{
+		MountTarget: filestorage.MountTarget{
+			PrivateIpIds: ServerIPs,
+			Id:           &CreatedMountTargetID},
+	}, nil
 }
 
 // GetMountTarget mocks the FileStorage GetMountTarget implementation
 func (c *MockFileStorageClient) GetMountTarget(ctx context.Context, request filestorage.GetMountTargetRequest) (response filestorage.GetMountTargetResponse, err error) {
-	return filestorage.GetMountTargetResponse{MountTarget: filestorage.MountTarget{PrivateIpIds: ServerIPs}}, nil
+	return filestorage.GetMountTargetResponse{
+		MountTarget: filestorage.MountTarget{
+			PrivateIpIds:   ServerIPs,
+			Id:             &CreatedMountTargetID,
+			LifecycleState: filestorage.MountTargetLifecycleStateActive},
+	}, nil
 }
 
 // ListMountTargets mocks the FileStorage ListMountTargets implementation

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,3 +1,5 @@
+no-response-timeout: 30
+command-timeout: 30
 box: golang:1.9
 
 dev:


### PR DESCRIPTION
This branch fixes a few critical bugs in the FSS implementation. Notably it makes sure that we block / await on the creation of OCI resources before proceeding to provision other resources. We have removed the ability to select a random mount target, thus simplifying the control flow and code.

Documentation will need to be updated.